### PR TITLE
SystemUI: Show bluetooth battery level when available

### DIFF
--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_0.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_0.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+**
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="20dp"
+        android:height="17dp"
+        android:viewportWidth="21.0"
+        android:viewportHeight="18.0">
+    <group
+        android:scaleX="0.75"
+        android:scaleY="0.75">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    </group>
+    <group
+        android:translateY="0.5"
+        android:translateX="0.5" >
+        <path
+            android:pathData="M15.77,1.064V15.94h3V1.064Z"
+            android:fillColor="#4DFFFFFF"/>
+        <path
+            android:pathData="M15.77,15.3V15.94h3V15.3Z"
+            android:fillColor="#FFFFFF"/>
+    </group>
+</vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_0.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_0.xml
@@ -1,47 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-**
-** Copyright 2017, The Android Open Source Project
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-*/
+<!-- Copyright (C) 2020 Paranoid Android
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="20dp"
-        android:height="17dp"
-        android:viewportWidth="21.0"
-        android:viewportHeight="18.0">
-    <group
-        android:scaleX="0.75"
-        android:scaleY="0.75">
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-    </group>
-    <group
-        android:translateY="0.5"
-        android:translateX="0.5" >
-        <path
-            android:pathData="M15.77,1.064V15.94h3V1.064Z"
-            android:fillColor="#4DFFFFFF"/>
-        <path
-            android:pathData="M15.77,15.3V15.94h3V15.3Z"
-            android:fillColor="#FFFFFF"/>
-    </group>
+    android:width="20dp"
+    android:height="17dp"
+    android:viewportWidth="20"
+    android:viewportHeight="17">
+  <path
+      android:pathData="M14.4583,1.4167C14.0671,1.4167 13.75,1.7338 13.75,2.125V14.875C13.75,15.2662 14.0671,15.5833 14.4583,15.5833H17.2917C17.6829,15.5833 18,15.2662 18,14.875V2.125C18,1.7338 17.6829,1.4167 17.2917,1.4167H14.4583ZM15.1667,2.8333H16.5833V13.3167H15.1667V2.8333Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M11.0046,5.4613L6.9601,1.4167H6.2517V6.7929L3.0005,3.5417L2.0017,4.5404L5.9613,8.5L2.0017,12.4596L3.0005,13.4583L6.2517,10.2071V15.5833H6.9601L11.0046,11.5388L7.9588,8.5L11.0046,5.4613ZM3.4184,7.7917C3.0272,7.4005 2.3929,7.4005 2.0017,7.7917C1.6105,8.1829 1.6105,8.8171 2.0017,9.2083C2.3929,9.5995 3.0272,9.5995 3.4184,9.2083C3.8096,8.8171 3.8096,8.1829 3.4184,7.7917ZM9.0001,5.4613L7.6684,4.1296V6.7929L9.0001,5.4613ZM9.0001,11.5388L7.6684,12.8704V10.2071L9.0001,11.5388ZM10.5017,7.7917C10.8929,7.4005 11.5272,7.4005 11.9184,7.7917C12.3096,8.1829 12.3096,8.8171 11.9184,9.2083C11.5272,9.5995 10.8929,9.5995 10.5017,9.2083C10.1105,8.8171 10.1105,8.1829 10.5017,7.7917Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
 </vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_1.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_1.xml
@@ -1,47 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-**
-** Copyright 2017, The Android Open Source Project
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-*/
+<!-- Copyright (C) 2020 Paranoid Android
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="20dp"
-        android:height="17dp"
-        android:viewportWidth="21.0"
-        android:viewportHeight="18.0">
-    <group
-        android:scaleX="0.75"
-        android:scaleY="0.75">
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-    </group>
-    <group
-        android:translateY="0.5"
-        android:translateX="0.5" >
-        <path
-            android:pathData="M15.77,1.064V15.94h3V1.064Z"
-            android:fillColor="#4DFFFFFF"/>
-        <path
-            android:pathData="M15.77,13.6V15.94h3V13.6Z"
-            android:fillColor="#FFFFFF"/>
-    </group>
+    android:width="20dp"
+    android:height="17dp"
+    android:viewportWidth="20"
+    android:viewportHeight="17">
+  <path
+      android:pathData="M11.0046,5.4613L6.9601,1.4167H6.2517V6.7929L3.0005,3.5417L2.0017,4.5404L5.9613,8.5L2.0017,12.4596L3.0005,13.4583L6.2517,10.2071V15.5833H6.9601L11.0046,11.5388L7.9588,8.5L11.0046,5.4613ZM3.4184,7.7917C3.0272,7.4005 2.3929,7.4005 2.0017,7.7917C1.6105,8.1829 1.6105,8.8171 2.0017,9.2083C2.3929,9.5995 3.0272,9.5995 3.4184,9.2083C3.8096,8.8171 3.8096,8.1829 3.4184,7.7917ZM9.0001,5.4613L7.6684,4.1296V6.7929L9.0001,5.4613ZM9.0001,11.5388L7.6684,12.8704V10.2071L9.0001,11.5388ZM10.5017,7.7917C10.8929,7.4005 11.5272,7.4005 11.9184,7.7917C12.3096,8.1829 12.3096,8.8171 11.9184,9.2083C11.5272,9.5995 10.8929,9.5995 10.5017,9.2083C10.1105,8.8171 10.1105,8.1829 10.5017,7.7917Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M14.4583,1.4167C14.0671,1.4167 13.75,1.7338 13.75,2.125V14.875C13.75,15.2662 14.0671,15.5833 14.4583,15.5833H17.2917C17.6829,15.5833 18,15.2662 18,14.875V2.125C18,1.7338 17.6829,1.4167 17.2917,1.4167H14.4583ZM15.1667,2.8333H16.5833V12.1833H15.1667V2.8333Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
 </vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_1.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_1.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+**
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="20dp"
+        android:height="17dp"
+        android:viewportWidth="21.0"
+        android:viewportHeight="18.0">
+    <group
+        android:scaleX="0.75"
+        android:scaleY="0.75">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    </group>
+    <group
+        android:translateY="0.5"
+        android:translateX="0.5" >
+        <path
+            android:pathData="M15.77,1.064V15.94h3V1.064Z"
+            android:fillColor="#4DFFFFFF"/>
+        <path
+            android:pathData="M15.77,13.6V15.94h3V13.6Z"
+            android:fillColor="#FFFFFF"/>
+    </group>
+</vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_2.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_2.xml
@@ -1,47 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-**
-** Copyright 2017, The Android Open Source Project
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-*/
+<!-- Copyright (C) 2020 Paranoid Android
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="20dp"
-        android:height="17dp"
-        android:viewportWidth="21.0"
-        android:viewportHeight="18.0">
-    <group
-        android:scaleX="0.75"
-        android:scaleY="0.75">
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-    </group>
-    <group
-        android:translateY="0.5"
-        android:translateX="0.5" >
-        <path
-            android:pathData="M15.77,1.064V15.94h3V1.064Z"
-            android:fillColor="#4DFFFFFF"/>
-        <path
-            android:pathData="M15.77,11.9V15.94h3V11.9Z"
-            android:fillColor="#FFFFFF"/>
-    </group>
+    android:width="20dp"
+    android:height="17dp"
+    android:viewportWidth="20"
+    android:viewportHeight="17">
+  <path
+      android:pathData="M14.4583,1.4167C14.0671,1.4167 13.75,1.7338 13.75,2.125V14.875C13.75,15.2662 14.0671,15.5833 14.4583,15.5833H17.2917C17.6829,15.5833 18,15.2662 18,14.875V2.125C18,1.7338 17.6829,1.4167 17.2917,1.4167H14.4583ZM15.1667,2.8333H16.5833V10.2H15.1667V2.8333Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M11.0047,5.4613L6.9601,1.4167H6.2517V6.7929L3.0005,3.5417L2.0017,4.5404L5.9613,8.5L2.0017,12.4596L3.0005,13.4583L6.2517,10.2071V15.5833H6.9601L11.0047,11.5388L7.9588,8.5L11.0047,5.4613ZM3.4184,7.7917C3.0272,7.4005 2.3929,7.4005 2.0017,7.7917C1.6105,8.1829 1.6105,8.8171 2.0017,9.2083C2.3929,9.5995 3.0272,9.5995 3.4184,9.2083C3.8096,8.8171 3.8096,8.1829 3.4184,7.7917ZM9.0001,5.4613L7.6684,4.1296V6.7929L9.0001,5.4613ZM9.0001,11.5388L7.6684,12.8704V10.2071L9.0001,11.5388ZM10.5017,7.7917C10.8929,7.4005 11.5272,7.4005 11.9184,7.7917C12.3096,8.1829 12.3096,8.8171 11.9184,9.2083C11.5272,9.5995 10.8929,9.5995 10.5017,9.2083C10.1105,8.8171 10.1105,8.1829 10.5017,7.7917Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
 </vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_2.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_2.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+**
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="20dp"
+        android:height="17dp"
+        android:viewportWidth="21.0"
+        android:viewportHeight="18.0">
+    <group
+        android:scaleX="0.75"
+        android:scaleY="0.75">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    </group>
+    <group
+        android:translateY="0.5"
+        android:translateX="0.5" >
+        <path
+            android:pathData="M15.77,1.064V15.94h3V1.064Z"
+            android:fillColor="#4DFFFFFF"/>
+        <path
+            android:pathData="M15.77,11.9V15.94h3V11.9Z"
+            android:fillColor="#FFFFFF"/>
+    </group>
+</vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_3.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_3.xml
@@ -1,47 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-**
-** Copyright 2017, The Android Open Source Project
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-*/
+<!-- Copyright (C) 2020 Paranoid Android
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="20dp"
-        android:height="17dp"
-        android:viewportWidth="21.0"
-        android:viewportHeight="18.0">
-    <group
-        android:scaleX="0.75"
-        android:scaleY="0.75">
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-    </group>
-    <group
-        android:translateY="0.5"
-        android:translateX="0.5" >
-        <path
-            android:pathData="M15.77,1.064V15.94h3V1.064Z"
-            android:fillColor="#4DFFFFFF"/>
-        <path
-            android:pathData="M15.77,10.2V15.94h3V10.2Z"
-            android:fillColor="#FFFFFF"/>
-    </group>
+    android:width="20dp"
+    android:height="17dp"
+    android:viewportWidth="20"
+    android:viewportHeight="17">
+  <path
+      android:pathData="M14.4583,1.4167C14.0671,1.4167 13.75,1.7338 13.75,2.125V14.875C13.75,15.2662 14.0671,15.5833 14.4583,15.5833H17.2917C17.6829,15.5833 18,15.2662 18,14.875V2.125C18,1.7338 17.6829,1.4167 17.2917,1.4167H14.4583ZM16.5833,2.8333H15.1667V9.35H16.5833V2.8333Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M11.0047,5.4613L6.9601,1.4167H6.2517V6.7929L3.0005,3.5417L2.0017,4.5404L5.9613,8.5L2.0017,12.4596L3.0005,13.4583L6.2517,10.2071V15.5833H6.9601L11.0047,11.5388L7.9588,8.5L11.0047,5.4613ZM3.4184,7.7917C3.0272,7.4005 2.3929,7.4005 2.0017,7.7917C1.6105,8.1829 1.6105,8.8171 2.0017,9.2083C2.3929,9.5995 3.0272,9.5995 3.4184,9.2083C3.8096,8.8171 3.8096,8.1829 3.4184,7.7917ZM9.0001,5.4613L7.6684,4.1296V6.7929L9.0001,5.4613ZM9.0001,11.5388L7.6684,12.8704V10.2071L9.0001,11.5388ZM10.5017,7.7917C10.8929,7.4005 11.5272,7.4005 11.9184,7.7917C12.3096,8.1829 12.3096,8.8171 11.9184,9.2083C11.5272,9.5995 10.8929,9.5995 10.5017,9.2083C10.1105,8.8171 10.1105,8.1829 10.5017,7.7917Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
 </vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_3.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_3.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+**
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="20dp"
+        android:height="17dp"
+        android:viewportWidth="21.0"
+        android:viewportHeight="18.0">
+    <group
+        android:scaleX="0.75"
+        android:scaleY="0.75">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    </group>
+    <group
+        android:translateY="0.5"
+        android:translateX="0.5" >
+        <path
+            android:pathData="M15.77,1.064V15.94h3V1.064Z"
+            android:fillColor="#4DFFFFFF"/>
+        <path
+            android:pathData="M15.77,10.2V15.94h3V10.2Z"
+            android:fillColor="#FFFFFF"/>
+    </group>
+</vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_4.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_4.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+**
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="20dp"
+        android:height="17dp"
+        android:viewportWidth="21.0"
+        android:viewportHeight="18.0">
+    <group
+        android:scaleX="0.75"
+        android:scaleY="0.75">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    </group>
+    <group
+        android:translateY="0.5"
+        android:translateX="0.5" >
+        <path
+            android:pathData="M15.77,1.064V15.94h3V1.064Z"
+            android:fillColor="#4DFFFFFF"/>
+        <path
+            android:pathData="M15.77,8.5V15.94h3V8.5Z"
+            android:fillColor="#FFFFFF"/>
+    </group>
+</vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_4.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_4.xml
@@ -1,47 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-**
-** Copyright 2017, The Android Open Source Project
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-*/
+<!-- Copyright (C) 2020 Paranoid Android
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="20dp"
-        android:height="17dp"
-        android:viewportWidth="21.0"
-        android:viewportHeight="18.0">
-    <group
-        android:scaleX="0.75"
-        android:scaleY="0.75">
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-    </group>
-    <group
-        android:translateY="0.5"
-        android:translateX="0.5" >
-        <path
-            android:pathData="M15.77,1.064V15.94h3V1.064Z"
-            android:fillColor="#4DFFFFFF"/>
-        <path
-            android:pathData="M15.77,8.5V15.94h3V8.5Z"
-            android:fillColor="#FFFFFF"/>
-    </group>
+    android:width="20dp"
+    android:height="17dp"
+    android:viewportWidth="20"
+    android:viewportHeight="17">
+  <path
+      android:pathData="M14.4583,1.4167C14.0671,1.4167 13.75,1.7338 13.75,2.125V14.875C13.75,15.2662 14.0671,15.5833 14.4583,15.5833H17.2917C17.6829,15.5833 18,15.2662 18,14.875V2.125C18,1.7338 17.6829,1.4167 17.2917,1.4167H14.4583ZM15.1667,2.8333H16.5833V7.0833H15.1667V2.8333Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M11.0046,5.4613L6.9601,1.4167H6.2517V6.7929L3.0005,3.5417L2.0017,4.5404L5.9613,8.5L2.0017,12.4596L3.0005,13.4583L6.2517,10.2071V15.5833H6.9601L11.0046,11.5388L7.9588,8.5L11.0046,5.4613ZM3.4184,7.7917C3.0272,7.4005 2.3929,7.4005 2.0017,7.7917C1.6105,8.1829 1.6105,8.8171 2.0017,9.2083C2.3929,9.5995 3.0272,9.5995 3.4184,9.2083C3.8096,8.8171 3.8096,8.1829 3.4184,7.7917ZM9.0001,5.4613L7.6684,4.1296V6.7929L9.0001,5.4613ZM9.0001,11.5388L7.6684,12.8704V10.2071L9.0001,11.5388ZM10.5017,7.7917C10.8929,7.4005 11.5272,7.4005 11.9184,7.7917C12.3096,8.1829 12.3096,8.8171 11.9184,9.2083C11.5272,9.5995 10.8929,9.5995 10.5017,9.2083C10.1105,8.8171 10.1105,8.1829 10.5017,7.7917Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
 </vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_5.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_5.xml
@@ -1,47 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-**
-** Copyright 2017, The Android Open Source Project
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-*/
+<!-- Copyright (C) 2020 Paranoid Android
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="20dp"
-        android:height="17dp"
-        android:viewportWidth="21.0"
-        android:viewportHeight="18.0">
-    <group
-        android:scaleX="0.75"
-        android:scaleY="0.75">
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-    </group>
-    <group
-        android:translateY="0.5"
-        android:translateX="0.5" >
-        <path
-            android:pathData="M15.77,1.064V15.94h3V1.064Z"
-            android:fillColor="#4DFFFFFF"/>
-        <path
-            android:pathData="M15.77,6.8V15.94h3V6.8Z"
-            android:fillColor="#FFFFFF"/>
-    </group>
+    android:width="20dp"
+    android:height="17dp"
+    android:viewportWidth="20"
+    android:viewportHeight="17">
+  <path
+      android:pathData="M14.4583,1.4167C14.0671,1.4167 13.75,1.7338 13.75,2.125V14.875C13.75,15.2662 14.0671,15.5833 14.4583,15.5833H17.2917C17.6829,15.5833 18,15.2662 18,14.875V2.125C18,1.7338 17.6829,1.4167 17.2917,1.4167H14.4583ZM15.1667,2.8333H16.5833V6.2333H15.1667V2.8333Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M11.0046,5.4613L6.9601,1.4167H6.2517V6.7929L3.0005,3.5417L2.0017,4.5404L5.9613,8.5L2.0017,12.4596L3.0005,13.4583L6.2517,10.2071V15.5833H6.9601L11.0046,11.5388L7.9588,8.5L11.0046,5.4613ZM3.4184,7.7917C3.0272,7.4005 2.3929,7.4005 2.0017,7.7917C1.6105,8.1829 1.6105,8.8171 2.0017,9.2083C2.3929,9.5995 3.0272,9.5995 3.4184,9.2083C3.8096,8.8171 3.8096,8.1829 3.4184,7.7917ZM9.0001,5.4613L7.6684,4.1296V6.7929L9.0001,5.4613ZM9.0001,11.5388L7.6684,12.8704V10.2071L9.0001,11.5388ZM10.5017,7.7917C10.8929,7.4005 11.5272,7.4005 11.9184,7.7917C12.3096,8.1829 12.3096,8.8171 11.9184,9.2083C11.5272,9.5995 10.8929,9.5995 10.5017,9.2083C10.1105,8.8171 10.1105,8.1829 10.5017,7.7917Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
 </vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_5.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_5.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+**
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="20dp"
+        android:height="17dp"
+        android:viewportWidth="21.0"
+        android:viewportHeight="18.0">
+    <group
+        android:scaleX="0.75"
+        android:scaleY="0.75">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    </group>
+    <group
+        android:translateY="0.5"
+        android:translateX="0.5" >
+        <path
+            android:pathData="M15.77,1.064V15.94h3V1.064Z"
+            android:fillColor="#4DFFFFFF"/>
+        <path
+            android:pathData="M15.77,6.8V15.94h3V6.8Z"
+            android:fillColor="#FFFFFF"/>
+    </group>
+</vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_6.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_6.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+**
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="20dp"
+        android:height="17dp"
+        android:viewportWidth="21.0"
+        android:viewportHeight="18.0">
+    <group
+        android:scaleX="0.75"
+        android:scaleY="0.75">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    </group>
+    <group
+        android:translateY="0.5"
+        android:translateX="0.5" >
+        <path
+            android:pathData="M15.77,1.064V15.94h3V1.064Z"
+            android:fillColor="#4DFFFFFF"/>
+        <path
+            android:pathData="M15.77,5.1V15.94h3V5.1Z"
+            android:fillColor="#FFFFFF"/>
+    </group>
+</vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_6.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_6.xml
@@ -1,47 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-**
-** Copyright 2017, The Android Open Source Project
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-*/
+<!-- Copyright (C) 2020 Paranoid Android
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="20dp"
-        android:height="17dp"
-        android:viewportWidth="21.0"
-        android:viewportHeight="18.0">
-    <group
-        android:scaleX="0.75"
-        android:scaleY="0.75">
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-    </group>
-    <group
-        android:translateY="0.5"
-        android:translateX="0.5" >
-        <path
-            android:pathData="M15.77,1.064V15.94h3V1.064Z"
-            android:fillColor="#4DFFFFFF"/>
-        <path
-            android:pathData="M15.77,5.1V15.94h3V5.1Z"
-            android:fillColor="#FFFFFF"/>
-    </group>
+    android:width="20dp"
+    android:height="17dp"
+    android:viewportWidth="20"
+    android:viewportHeight="17">
+  <path
+      android:pathData="M14.4583,1.4167C14.0671,1.4167 13.75,1.7338 13.75,2.125V14.875C13.75,15.2662 14.0671,15.5833 14.4583,15.5833H17.2917C17.6829,15.5833 18,15.2662 18,14.875V2.125C18,1.7338 17.6829,1.4167 17.2917,1.4167H14.4583ZM15.1667,2.8333H16.5833V5.3833H15.1667V2.8333Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M11.0046,5.4613L6.9601,1.4167H6.2517V6.7929L3.0005,3.5417L2.0017,4.5404L5.9613,8.5L2.0017,12.4596L3.0005,13.4583L6.2517,10.2071V15.5833H6.9601L11.0046,11.5388L7.9588,8.5L11.0046,5.4613ZM3.4184,7.7917C3.0272,7.4005 2.3929,7.4005 2.0017,7.7917C1.6105,8.1829 1.6105,8.8171 2.0017,9.2083C2.3929,9.5995 3.0272,9.5995 3.4184,9.2083C3.8096,8.8171 3.8096,8.1829 3.4184,7.7917ZM9.0001,5.4613L7.6684,4.1296V6.7929L9.0001,5.4613ZM9.0001,11.5388L7.6684,12.8704V10.2071L9.0001,11.5388ZM10.5017,7.7917C10.8929,7.4005 11.5272,7.4005 11.9184,7.7917C12.3096,8.1829 12.3096,8.8171 11.9184,9.2083C11.5272,9.5995 10.8929,9.5995 10.5017,9.2083C10.1105,8.8171 10.1105,8.1829 10.5017,7.7917Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
 </vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_7.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_7.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+**
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="20dp"
+        android:height="17dp"
+        android:viewportWidth="21.0"
+        android:viewportHeight="18.0">
+    <group
+        android:scaleX="0.75"
+        android:scaleY="0.75">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    </group>
+    <group
+        android:translateY="0.5"
+        android:translateX="0.5" >
+        <path
+            android:pathData="M15.77,1.064V15.94h3V1.064Z"
+            android:fillColor="#4DFFFFFF"/>
+        <path
+            android:pathData="M15.77,3.4V15.94h3V3.4Z"
+            android:fillColor="#FFFFFF"/>
+    </group>
+</vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_7.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_7.xml
@@ -1,47 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-**
-** Copyright 2017, The Android Open Source Project
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-*/
+<!-- Copyright (C) 2020 Paranoid Android
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="20dp"
-        android:height="17dp"
-        android:viewportWidth="21.0"
-        android:viewportHeight="18.0">
-    <group
-        android:scaleX="0.75"
-        android:scaleY="0.75">
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-    </group>
-    <group
-        android:translateY="0.5"
-        android:translateX="0.5" >
-        <path
-            android:pathData="M15.77,1.064V15.94h3V1.064Z"
-            android:fillColor="#4DFFFFFF"/>
-        <path
-            android:pathData="M15.77,3.4V15.94h3V3.4Z"
-            android:fillColor="#FFFFFF"/>
-    </group>
+    android:width="20dp"
+    android:height="17dp"
+    android:viewportWidth="20"
+    android:viewportHeight="17">
+  <path
+      android:pathData="M14.4583,1.4167C14.0671,1.4167 13.75,1.7338 13.75,2.125V14.875C13.75,15.2662 14.0671,15.5833 14.4583,15.5833H17.2917C17.6829,15.5833 18,15.2662 18,14.875V2.125C18,1.7338 17.6829,1.4167 17.2917,1.4167H14.4583ZM15.1667,2.8333H16.5833V4.5333H15.1667V2.8333Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M11.0046,5.4613L6.9601,1.4167H6.2517V6.7929L3.0005,3.5417L2.0017,4.5404L5.9613,8.5L2.0017,12.4596L3.0005,13.4583L6.2517,10.2071V15.5833H6.9601L11.0046,11.5388L7.9588,8.5L11.0046,5.4613ZM3.4184,7.7917C3.0272,7.4005 2.3929,7.4005 2.0017,7.7917C1.6105,8.1829 1.6105,8.8171 2.0017,9.2083C2.3929,9.5995 3.0272,9.5995 3.4184,9.2083C3.8096,8.8171 3.8096,8.1829 3.4184,7.7917ZM9.0001,5.4613L7.6684,4.1296V6.7929L9.0001,5.4613ZM9.0001,11.5388L7.6684,12.8704V10.2071L9.0001,11.5388ZM10.5017,7.7917C10.8929,7.4005 11.5272,7.4005 11.9184,7.7917C12.3096,8.1829 12.3096,8.8171 11.9184,9.2083C11.5272,9.5995 10.8929,9.5995 10.5017,9.2083C10.1105,8.8171 10.1105,8.1829 10.5017,7.7917Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
 </vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_8.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_8.xml
@@ -1,47 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-**
-** Copyright 2017, The Android Open Source Project
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-*/
+<!-- Copyright (C) 2020 Paranoid Android
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="20dp"
-        android:height="17dp"
-        android:viewportWidth="21.0"
-        android:viewportHeight="18.0">
-    <group
-        android:scaleX="0.75"
-        android:scaleY="0.75">
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-    </group>
-    <group
-        android:translateY="0.5"
-        android:translateX="0.5" >
-        <path
-            android:pathData="M15.77,1.064V15.94h3V1.064Z"
-            android:fillColor="#4DFFFFFF"/>
-        <path
-            android:pathData="M15.77,1.7V15.94h3V1.7Z"
-            android:fillColor="#FFFFFF"/>
-    </group>
+    android:width="20dp"
+    android:height="17dp"
+    android:viewportWidth="20"
+    android:viewportHeight="17">
+  <path
+      android:pathData="M14.4583,1.4167C14.0671,1.4167 13.75,1.7338 13.75,2.125V14.875C13.75,15.2662 14.0671,15.5833 14.4583,15.5833H17.2917C17.6829,15.5833 18,15.2662 18,14.875V2.125C18,1.7338 17.6829,1.4167 17.2917,1.4167H14.4583ZM15.1667,2.8333H16.5833V3.6833H15.1667V2.8333Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M11.0047,5.4613L6.9601,1.4167H6.2517V6.7929L3.0005,3.5417L2.0017,4.5404L5.9613,8.5L2.0017,12.4596L3.0005,13.4583L6.2517,10.2071V15.5833H6.9601L11.0047,11.5388L7.9588,8.5L11.0047,5.4613ZM3.4184,7.7917C3.0272,7.4005 2.393,7.4005 2.0017,7.7917C1.6105,8.1829 1.6105,8.8171 2.0017,9.2083C2.393,9.5995 3.0272,9.5995 3.4184,9.2083C3.8096,8.8171 3.8096,8.1829 3.4184,7.7917ZM9.0001,5.4613L7.6684,4.1296V6.7929L9.0001,5.4613ZM9.0001,11.5388L7.6684,12.8704V10.2071L9.0001,11.5388ZM10.5017,7.7917C10.8929,7.4005 11.5272,7.4005 11.9184,7.7917C12.3096,8.1829 12.3096,8.8171 11.9184,9.2083C11.5272,9.5995 10.8929,9.5995 10.5017,9.2083C10.1105,8.8171 10.1105,8.1829 10.5017,7.7917Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
 </vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_8.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_8.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+**
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="20dp"
+        android:height="17dp"
+        android:viewportWidth="21.0"
+        android:viewportHeight="18.0">
+    <group
+        android:scaleX="0.75"
+        android:scaleY="0.75">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    </group>
+    <group
+        android:translateY="0.5"
+        android:translateX="0.5" >
+        <path
+            android:pathData="M15.77,1.064V15.94h3V1.064Z"
+            android:fillColor="#4DFFFFFF"/>
+        <path
+            android:pathData="M15.77,1.7V15.94h3V1.7Z"
+            android:fillColor="#FFFFFF"/>
+    </group>
+</vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_9.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_9.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+**
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="20dp"
+        android:height="17dp"
+        android:viewportWidth="21.0"
+        android:viewportHeight="18.0">
+    <group
+        android:scaleX="0.75"
+        android:scaleY="0.75">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    </group>
+    <group
+        android:translateY="0.5"
+        android:translateX="0.5" >
+        <path
+            android:pathData="M15.77,1.064V15.94h3V1.064Z"
+            android:fillColor="#FFFFFF"/>
+    </group>
+</vector>

--- a/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_9.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_data_bluetooth_connected_battery_9.xml
@@ -1,44 +1,27 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-**
-** Copyright 2017, The Android Open Source Project
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-*/
+<!-- Copyright (C) 2020 Paranoid Android
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="20dp"
-        android:height="17dp"
-        android:viewportWidth="21.0"
-        android:viewportHeight="18.0">
-    <group
-        android:scaleX="0.75"
-        android:scaleY="0.75">
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M5,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M19,12m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
-    </group>
-    <group
-        android:translateY="0.5"
-        android:translateX="0.5" >
-        <path
-            android:pathData="M15.77,1.064V15.94h3V1.064Z"
-            android:fillColor="#FFFFFF"/>
-    </group>
+    android:width="20dp"
+    android:height="17dp"
+    android:viewportWidth="20"
+    android:viewportHeight="17">
+  <path
+      android:pathData="M13.75,2.125C13.75,1.7338 14.0671,1.4167 14.4583,1.4167H17.2917C17.6829,1.4167 18,1.7338 18,2.125V14.875C18,15.2662 17.6829,15.5833 17.2917,15.5833H14.4583C14.0671,15.5833 13.75,15.2662 13.75,14.875V2.125Z"
+      android:fillColor="#000000"/>
+  <path
+      android:pathData="M11.0047,5.4613L6.9601,1.4167H6.2517V6.7929L3.0005,3.5417L2.0017,4.5404L5.9613,8.5L2.0017,12.4596L3.0005,13.4583L6.2517,10.2071V15.5833H6.9601L11.0047,11.5388L7.9588,8.5L11.0047,5.4613ZM3.4184,7.7917C3.0272,7.4005 2.393,7.4005 2.0017,7.7917C1.6105,8.1829 1.6105,8.8171 2.0017,9.2083C2.393,9.5995 3.0272,9.5995 3.4184,9.2083C3.8096,8.8171 3.8096,8.1829 3.4184,7.7917ZM9.0001,5.4613L7.6684,4.1296V6.7929L9.0001,5.4613ZM9.0001,11.5388L7.6684,12.8704V10.2071L9.0001,11.5388ZM10.5017,7.7917C10.8929,7.4005 11.5272,7.4005 11.9184,7.7917C12.3096,8.1829 12.3096,8.8171 11.9184,9.2083C11.5272,9.5995 10.8929,9.5995 10.5017,9.2083C10.1105,8.8171 10.1105,8.1829 10.5017,7.7917Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
 </vector>

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarPolicy.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarPolicy.java
@@ -22,6 +22,7 @@ import android.app.AlarmManager;
 import android.app.AlarmManager.AlarmClockInfo;
 import android.app.IActivityManager;
 import android.app.SynchronousUserSwitchObserver;
+import android.bluetooth.BluetoothDevice;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -42,6 +43,7 @@ import android.view.View;
 
 import androidx.lifecycle.Observer;
 
+import com.android.settingslib.bluetooth.CachedBluetoothDevice;
 import com.android.systemui.R;
 import com.android.systemui.broadcast.BroadcastDispatcher;
 import com.android.systemui.dagger.qualifiers.DisplayId;
@@ -236,6 +238,7 @@ public class PhoneStatusBarPolicy
 
         filter.addAction(AudioManager.ACTION_HEADSET_PLUG);
         filter.addAction(Intent.ACTION_SIM_STATE_CHANGED);
+        filter.addAction(BluetoothDevice.ACTION_BATTERY_LEVEL_CHANGED);
         filter.addAction(TelecomManager.ACTION_CURRENT_TTY_MODE_CHANGED);
         filter.addAction(Intent.ACTION_MANAGED_PROFILE_AVAILABLE);
         filter.addAction(Intent.ACTION_MANAGED_PROFILE_UNAVAILABLE);
@@ -450,6 +453,30 @@ public class PhoneStatusBarPolicy
             if (mBluetooth.isBluetoothConnected()
                     && (mBluetooth.isBluetoothAudioActive()
                     || !mBluetooth.isBluetoothAudioProfileOnly())) {
+                List<CachedBluetoothDevice> connectedDevices = mBluetooth.getConnectedDevices();
+                int batteryLevel = connectedDevices.isEmpty() ?
+                        -1 : connectedDevices.get(0).getBatteryLevel();
+                if (batteryLevel == 100) {
+                    iconId = R.drawable.stat_sys_data_bluetooth_connected_battery_9;
+                } else if (batteryLevel >= 90) {
+                    iconId = R.drawable.stat_sys_data_bluetooth_connected_battery_8;
+                } else if (batteryLevel >= 80) {
+                    iconId = R.drawable.stat_sys_data_bluetooth_connected_battery_7;
+                } else if (batteryLevel >= 70) {
+                    iconId = R.drawable.stat_sys_data_bluetooth_connected_battery_6;
+                } else if (batteryLevel >= 60) {
+                    iconId = R.drawable.stat_sys_data_bluetooth_connected_battery_5;
+                } else if (batteryLevel >= 50) {
+                    iconId = R.drawable.stat_sys_data_bluetooth_connected_battery_4;
+                } else if (batteryLevel >= 40) {
+                    iconId = R.drawable.stat_sys_data_bluetooth_connected_battery_3;
+                } else if (batteryLevel >= 30) {
+                    iconId = R.drawable.stat_sys_data_bluetooth_connected_battery_2;
+                } else if (batteryLevel >= 20) {
+                    iconId = R.drawable.stat_sys_data_bluetooth_connected_battery_1;
+                } else if (batteryLevel >= 10) {
+                    iconId = R.drawable.stat_sys_data_bluetooth_connected_battery_0;
+                }
                 contentDescription = mResources.getString(
                         R.string.accessibility_bluetooth_connected);
                 bluetoothVisible = mBluetooth.isBluetoothEnabled();
@@ -728,6 +755,9 @@ public class PhoneStatusBarPolicy
                     break;
                 case AudioManager.ACTION_HEADSET_PLUG:
                     updateHeadsetPlug(intent);
+                    break;
+                case BluetoothDevice.ACTION_BATTERY_LEVEL_CHANGED:
+                    updateBluetooth();
                     break;
             }
         }


### PR DESCRIPTION
* Somewhat inspired by change committed by Gavin Ni <gisngy@gmail.com>
  back in cm-13.0 days (see commit 88e7a6c). Since then completely
  rewritten using BluetoothDevice API introduced in Oreo, with new
  drawables meant to be used with 0-9 battery level range.

Change-Id: I6179bfd41e033591534e8cf3c6adc98ce715a13d
Signed-off-by: Adithya R <gh0strider.2k18.reborn@gmail.com>